### PR TITLE
fix error in python 3.13

### DIFF
--- a/pnglatex/pnglatex.py
+++ b/pnglatex/pnglatex.py
@@ -72,11 +72,11 @@ def _cleanup(jobname):
     yield
 
     def _cleanup_suffix(suffix):
-        with Path(jobname + suffix) as p:
-            try:
-                p.unlink()
-            except FileNotFoundError:
-                pass
+        p = Path(jobname + suffix)
+        try:
+            p.unlink()
+        except FileNotFoundError:
+            pass
 
     for suf in ('.pdf', '.out', '.aux', '.log', '-crop.pdf'):
         _cleanup_suffix(suf)


### PR DESCRIPTION
Python 3.13 throws an error on the file cleanup pass which this change resolves. `'PosixPath' object does not support the context manager protocol`